### PR TITLE
Ot159 53 actualizacion actividades

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ const newsRouter = require('./routes/news');
 const organizationRouter = require('./routes/organizationRoutes');
 const authRouter = require('./routes/auth');
 const membersRouter = require('./routes/members');
+const activitiesRouter = require('./routes/activities')
 
 const app = express();
 app.use(cors())
@@ -36,7 +37,7 @@ app.use('/news', newsRouter);
 app.use('/organization', organizationRouter);
 app.use('/auth', authRouter)
 app.use('/testimonials', testimonialsRouter);
-
+app.use('/activities', activitiesRouter)
 
 app.use('/users', usersRouter);
 app.use('/members', membersRouter)

--- a/controllers/activitiesController.js
+++ b/controllers/activitiesController.js
@@ -1,9 +1,19 @@
-const activitiesRepository = require('../repositories/activitiesRepository');
+const activitiesService = require('../services/activitiesService')
 
-exports.get = async (req, res) => {
-   
+const updateActivity = async(req, res, next) => {
+    try {
+        const { id } = req.params
+        const { name, content, image } = req.body
+        const activity = await activitiesService.updateActivity({name, content, image}, id)
+        if(activity[0] === 0) {
+            return res.status(404).json(`The update with de id ${id} has failed`)
+        }
+        res.status(200).json({activityUpdated: {name, content, image}})
+    } catch (error) {
+        next(error)
+    }
 }
 
-exports.getById = async (req, res) => {
- 
+module.exports = {
+    updateActivity
 }

--- a/middlewares/validations/activities.js
+++ b/middlewares/validations/activities.js
@@ -1,0 +1,25 @@
+const { check, validationResult } = require('express-validator')
+
+const errorWrapperFunction = (req, res, next) => {
+    const result = validationResult(req);
+    const hasErrors = !result.isEmpty()
+    if (hasErrors) {
+      return res.status(422).json({ errorList: result.array() });
+    }
+    next();
+  };
+
+const validateActivities = [
+    check('name')
+        .notEmpty().withMessage('this field cannot be empty!').bail(),
+    
+    check('content')
+        .notEmpty().withMessage('this field cannot be empty!').bail(),
+    
+    check('image')
+        .notEmpty().withMessage('this field cannot be empty!').bail(),
+    
+    errorWrapperFunction
+]
+
+module.exports = {validateActivities}

--- a/repositories/activitiesRepository.js
+++ b/repositories/activitiesRepository.js
@@ -1,14 +1,14 @@
-const Activities = require('../models/activities');
+const db = require('../models')
 
-class ActivitiesRepository {
-
-    async findAll() {
-        return await Activities.findAll();
-    }
-
-    async findById(id) {
-        return await Activities.findByPk(id);
-    }
+const updateActivity = async (activityDataFields, id) => {
+    const activity = await db.Activities.update(activityDataFields, {
+        where: {
+            id
+        }
+    })
+    return activity
 }
 
-module.exports = ActivitiesRepository;
+module.exports = {
+    updateActivity
+}

--- a/routes/activities.js
+++ b/routes/activities.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const router = express.Router()
+
+const { updateActivity } = require('../controllers/activitiesController')
+const { validateActivities } = require('../middlewares/validations/activities')
+const { isAdminRole } = require('../middlewares/validateRoles')
+
+router.put('/:id', validateActivities, isAdminRole, updateActivity)
+
+module.exports = router

--- a/services/activitiesService.js
+++ b/services/activitiesService.js
@@ -1,15 +1,9 @@
-const ActivityRepository = require('../repositories/activitiesRepository');
-const repository = new ActivityRepository();
+const activitiesRepository = require('../repositories/activitiesRepository');
 
-const findAll = async (id) => {
-    return await repository.findAll();
-}
-
-const findById = async (id) => {
-    return await repository.findAll();
+const updateActivity = (activityDataFields, id) => {
+    return activitiesRepository.updateActivity(activityDataFields, id)
 }
 
 module.exports = {
-    findAll,
-    findById
+    updateActivity
 }


### PR DESCRIPTION
- Se cerró el PR #44 porque la branch no salía de la rama main sino del ticket Ot159-52.
- Se abre este nuevo PR partiendo desde la branch main y se corrigen los errores señalados en el PR #44 
- Al igual que en el ticket Ot159-52 al comenzar se borraron lineas que tenían que ver con un ticket anterior (OT159-21) en donde se hacían funciones (como por ej: get y getById) y se definian clases (ej: class ActivitiesRepository) que no tenían que ver con ese ticket.

----------------------------------------------------------------------------------------------

COMO usuario administrador
QUIERO actualizar una actividad existente
PARA mantener la información actualizada

Criterios de aceptación:
PUT /activities/:id - Deberá validar que la actividad exista en base al id enviado por parámetro. En el caso de que no exista devolver un error, caso contrario actualizarla y devolverla con los datos actualizados